### PR TITLE
backend: enable logging to salt local client

### DIFF
--- a/usm_wrappers/salt_wrapper.py
+++ b/usm_wrappers/salt_wrapper.py
@@ -140,6 +140,17 @@ def get_machine_id(minion_id):
     return out.get(minion_id, {}).get('machine_id')
 
 
+def get_minion_installed_storage(minion):
+    out = local.cmd(minion, 'pkg.list_pkgs')
+    pkgs = out.get(minion, {})
+    if pkgs.get('glusterfs-server'):
+        return 'GLUSTER'
+    elif pkgs.get('ceph'):
+        return 'CEPH'
+    else:
+        return 'UNKNOWN'
+
+
 def get_minion_network_info(minions):
     out = local.cmd(minions, ['grains.item', 'network.subnets'],
                     [['ipv4', 'ipv6'], []], expr_form='list')


### PR DESCRIPTION
This patch wraps salt.client.LocalClient.cmd() method where wrapped
function logs input argument/output value of the method call.

Signed-off-by: Bala.FA barumuga@redhat.com
