### PR TITLE
Install: add a script for setting up usm core

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ gevent==1.0.1
 
 psycogreen==1.0
 
-
+NOTE: few of the packages like djangorestframework, psycogreen are not available through yum,
+they have to be installed using pip tool.
 
 SETUP
 ------
@@ -79,7 +80,7 @@ create user - createuser -P usm
 
 go to the SQL prompt - psql
 
-Grant the db privileges newly created user - GRANT ALL PRIVILEGES ON DATABASE usm TO usm
+Grant the db privileges newly created user - GRANT ALL PRIVILEGES ON DATABASE usm TO usm;
 
 Start the salt service
 ----------------------
@@ -154,3 +155,15 @@ python manage.py runserver IPAddress:PORT
 Access the usm application using -
 
 http://IPADDRESS:PORT/
+
+Install Script
+--------------
+
+Alternatively Setup on a fresh machine can be done using install.sh script
+available in this repo. This script takes care of:
+*installing the necessary packages.
+*setting up the DB
+*setting up the USM app
+*setting up celery, salt and redis.
+
+This script has been tested on Fedora-22.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ gevent==1.0.1
 
 psycogreen==1.0
 
-
+NOTE: few of the packages like djangorestframework, psycogreen are not available through yum,
+they have to be installed using pip tool.
 
 SETUP
 ------
@@ -79,7 +80,7 @@ create user - createuser -P usm
 
 go to the SQL prompt - psql
 
-Grant the db privileges newly created user - GRANT ALL PRIVILEGES ON DATABASE usm TO usm
+Grant the db privileges newly created user - GRANT ALL PRIVILEGES ON DATABASE usm TO usm;
 
 Start the salt service
 ----------------------

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ printf "${GREEN}Installing necessary packages for USM${NC}\n"
 
 set -x
 
-yum -y install python-django python-django-celery python-django-extensions python-django-bash-completion python-django-filter python-paramiko redis python-redis salt-master postgresql postgresql-server postgresql-devel postgresql-libs postgresql-contrib python-psycopg2 python-netaddr python-cpopen python-gevent python-pip python-devel
+yum -y install python-django python-django-celery python-django-extensions python-django-bash-completion python-django-filter python-paramiko redis python-redis salt-master postgresql postgresql-server postgresql-devel postgresql-libs postgresql-contrib python-psycopg2 python-netaddr python-cpopen python-gevent python-pip python-devel wget tar
 
 pip install djangorestframework psycogreen
 pip install celery --upgrade
@@ -144,9 +144,34 @@ yes |cp $USM_HOME/usm_wrappers/*.sls /srv/salt
 
 set +x
 
-printf "${YELLOW}Please Make Suitable Firewall settings by unblocking 4505-4506 ports for communication with salt and your HTTP port used for USM....${NC}\n"
+while true; do
+    read -p "Do you wish to install USM-UI [Y/N]:" yn
+    case $yn in
+        [YyNn]* ) break;;
+        * ) echo "Please answer Y or N.";;
+    esac
+done
 
-printf "${GREEN}You Can start the USM application by running following command in $USM_HOME dir\nCommand: python manage.py runserver IPAddress:PORT${NC}\n"
+if [ $yn = "Y" -o $yn = "y" ]
+then
+    printf "${GREEN}Downloading and installing usm-client...${NC}\n"
+    set -x
+    wget http://github.com/kmkanagaraj/usm-client/releases/download/0.0.1/usm-client-0.0.1.tar.gz
+    mkdir static
+    tar -xzf usm-client-0.0.1.tar.gz -C static/
 
-printf "${GREEN}Access the application using http://IPADDRESS:PORT/api/v1${NC}\n"
+    set +x
+    printf "${YELLOW}Please Make Suitable Firewall settings by unblocking 4505-4506 ports for communication with salt and your HTTP port used for USM....${NC}\n"
 
+    printf "${GREEN}You Can start the USM application by running following command in $USM_HOME dir\nCommand: python manage.py runserver IPAddress:PORT${NC}\n"
+
+    printf "${GREEN}Access the application using http://IPADDRESS:PORT/static/index.html${NC}\n"
+else
+    set +x
+
+    printf "${YELLOW}Please Make Suitable Firewall settings by unblocking 4505-4506 ports for communication with salt and your HTTP port used for USM....${NC}\n"
+
+    printf "${GREEN}You Can start the USM application by running following command in $USM_HOME dir\nCommand: python manage.py runserver IPAddress:PORT${NC}\n"
+
+    printf "${GREEN}Access the application using http://IPADDRESS:PORT/api/v1${NC}\n"
+fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+set -e
+
+# Package installation
+
+RED='\033[0;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+printf "${GREEN}Installing necissary packages for USM${NC}\n"
+
+set -x
+
+yum -y install python-django python-django-celery python-django-extensions python-django-bash-completion python-django-filter python-paramiko redis python-redis salt-master postgresql postgresql-server postgresql-devel postgresql-libs postgresql-contrib python-psycopg2 python-netaddr python-cpopen python-gevent python-pip python-devel git
+
+pip install djangorestframework psycogreen celery
+
+# Initialize the DB
+
+set +x
+
+printf "${GREEN}Initializing the DB${NC}\n"
+
+set -x
+
+/usr/bin/postgresql-setup initdb
+
+# Configure PostgreSQL to accept network connection
+
+set +x
+
+printf "${GREEN}Configuring PostgreSQL to accept network connection${NC}\n"
+
+set -x
+
+sed -i 's/127.0.0.1\/32 *ident/127.0.0.1\/32            password/g'  /var/lib/pgsql/data/pg_hba.conf
+sed -i 's/::1\/128 *ident/::1\/128                 password/g'  /var/lib/pgsql/data/pg_hba.conf
+
+# Enable and start the postgresSQL service
+
+set +x
+
+printf "${GREEN}Enable and start the postgresSQL service${NC}\n"
+
+set -x
+
+systemctl enable postgresql
+
+systemctl start postgresql
+
+# Create the Database,User and grant privileges
+
+set +x
+
+printf "${GREEN}Creating the Database,User and granting privileges${NC}\n"
+
+set -x
+
+sudo su - postgres -c "createdb usm"
+
+sudo su - postgres -c "psql --command=\"CREATE USER usm WITH PASSWORD 'usm'\""
+
+sudo su - postgres -c "psql --command=\"GRANT ALL PRIVILEGES ON DATABASE usm TO usm\""
+
+
+# Start the salt service
+
+set +x
+
+printf "${GREEN}Starting salt service${NC}\n"
+
+set -x
+
+systemctl enable salt-master
+
+systemctl start salt-master
+
+# Clone Setup the USM App
+
+set +x
+
+printf "${GREEN}Cloning and setting USM app${NC}\n"
+
+set -x
+
+USM_HOME=$HOME/USM
+
+cd
+
+git clone https://github.com/nthomas-redhat/USM.git
+
+mkdir /var/log/usm
+
+cd USM
+
+python manage.py makemigrations
+
+python manage.py migrate
+
+set +x
+
+printf "${GREEN}Please Enter Details for USM super-user creation${NC}\n"
+
+set -x
+
+python manage.py createsuperuser
+
+
+# Celery setup
+
+set +x
+
+printf "${GREEN}Setting up Celery${NC}\n"
+
+set -x
+
+systemctl enable redis
+
+systemctl start redis
+
+sed -i 's|^CELERYD_CHDIR=.*|'CELERYD_CHDIR=\""$USM_HOME"\"'|g' $USM_HOME/celery/default/celeryd
+
+sed -i 's|^DJANGO_PROJECT_DIR=.*|'DJANGO_PROJECT_DIR=\""$USM_HOME"\"'|g' $USM_HOME/celery/default/celeryd
+
+yes |cp $USM_HOME/celery/default/celeryd /etc/default
+
+yes |cp $USM_HOME/celery/init.d/celeryd /etc/init.d
+
+mkdir -p -m 2755 /var/log/celery
+
+service celeryd start
+
+# Salt setup
+
+set +x
+
+printf "${GREEN}Setting up salt${NC}\n"
+
+set -x
+
+yes |cp $USM_HOME/usm_wrappers/setup-minion.sh.template $USM_HOME
+
+mkdir /srv/salt
+
+yes |cp $USM_HOME/usm_wrappers/*.sls /srv/salt
+
+set +x
+
+printf "${RED}Please Make Suitable Firewall settings by unblocking 4505-4506 ports for communication with salt and your HTTP port used for USM....${NC}\n"
+
+printf "${GREEN}You Can start the USM application by running following command in ~/USM dir\nCommand: python manage.py runserver IPAddress:PORT${NC}\n"
+
+printf "${GREEN}Access the application using http://IPADDRESS:PORT/api/v1${NC}\n"
+

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+set -e
+
+# Package installation
+
+RED='\033[0;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+USM_HOME=pwd
+
+printf "${GREEN}Installing necissary packages for USM${NC}\n"
+
+set -x
+
+yum -y install python-django python-django-celery python-django-extensions python-django-bash-completion python-django-filter python-paramiko redis python-redis salt-master postgresql postgresql-server postgresql-devel postgresql-libs postgresql-contrib python-psycopg2 python-netaddr python-cpopen python-gevent python-pip python-devel git
+
+pip install djangorestframework psycogreen celery
+
+# Initialize the DB
+
+set +x
+
+printf "${GREEN}Initializing the DB${NC}\n"
+
+set -x
+
+/usr/bin/postgresql-setup initdb
+
+# Configure PostgreSQL to accept network connection
+
+set +x
+
+printf "${GREEN}Configuring PostgreSQL to accept network connection${NC}\n"
+
+set -x
+
+sed -i 's/127.0.0.1\/32 *ident/127.0.0.1\/32            password/g'  /var/lib/pgsql/data/pg_hba.conf
+sed -i 's/::1\/128 *ident/::1\/128                 password/g'  /var/lib/pgsql/data/pg_hba.conf
+
+# Enable and start the postgresSQL service
+
+set +x
+
+printf "${GREEN}Enable and start the postgresSQL service${NC}\n"
+
+set -x
+
+systemctl enable postgresql
+
+systemctl start postgresql
+
+# Create the Database,User and grant privileges
+
+set +x
+
+printf "${GREEN}Creating the Database,User and granting privileges${NC}\n"
+
+set -x
+
+sudo su - postgres -c "createdb usm"
+
+sudo su - postgres -c "psql --command=\"CREATE USER usm WITH PASSWORD 'usm'\""
+
+sudo su - postgres -c "psql --command=\"GRANT ALL PRIVILEGES ON DATABASE usm TO usm\""
+
+
+# Start the salt service
+
+set +x
+
+printf "${GREEN}Starting salt service${NC}\n"
+
+set -x
+
+systemctl enable salt-master
+
+systemctl start salt-master
+
+# Setup the USM App
+
+set +x
+
+printf "${GREEN}Setting Up USM app${NC}\n"
+
+set -x
+
+mkdir /var/log/usm
+
+cd $USM_HOME
+
+python manage.py makemigrations
+
+python manage.py migrate
+
+set +x
+
+printf "${GREEN}Please Enter Details for USM super-user creation${NC}\n"
+
+set -x
+
+python manage.py createsuperuser
+
+
+# Celery setup
+
+set +x
+
+printf "${GREEN}Setting up Celery${NC}\n"
+
+set -x
+
+systemctl enable redis
+
+systemctl start redis
+
+sed -i 's|^CELERYD_CHDIR=.*|'CELERYD_CHDIR=\""$USM_HOME"\"'|g' $USM_HOME/celery/default/celeryd
+
+sed -i 's|^DJANGO_PROJECT_DIR=.*|'DJANGO_PROJECT_DIR=\""$USM_HOME"\"'|g' $USM_HOME/celery/default/celeryd
+
+yes |cp $USM_HOME/celery/default/celeryd /etc/default
+
+yes |cp $USM_HOME/celery/init.d/celeryd /etc/init.d
+
+mkdir -p -m 2755 /var/log/celery
+
+service celeryd start
+
+# Salt setup
+
+set +x
+
+printf "${GREEN}Setting up salt${NC}\n"
+
+set -x
+
+yes |cp $USM_HOME/usm_wrappers/setup-minion.sh.template $USM_HOME
+
+mkdir /srv/salt
+
+yes |cp $USM_HOME/usm_wrappers/*.sls /srv/salt
+
+set +x
+
+printf "${RED}Please Make Suitable Firewall settings by unblocking 4505-4506 ports for communication with salt and your HTTP port used for USM....${NC}\n"
+
+printf "${GREEN}You Can start the USM application by running following command in $USM_HOME dir\nCommand: python manage.py runserver IPAddress:PORT${NC}\n"
+
+printf "${GREEN}Access the application using http://IPADDRESS:PORT/api/v1${NC}\n"
+

--- a/install.sh
+++ b/install.sh
@@ -4,17 +4,17 @@ set -e
 
 # Package installation
 
-RED='\033[0;33m'
+YELLOW='\033[0;33m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
 USM_HOME=`pwd`
 
-printf "${GREEN}Installing necissary packages for USM${NC}\n"
+printf "${GREEN}Installing necessary packages for USM${NC}\n"
 
 set -x
 
-yum -y install python-django python-django-celery python-django-extensions python-django-bash-completion python-django-filter python-paramiko redis python-redis salt-master postgresql postgresql-server postgresql-devel postgresql-libs postgresql-contrib python-psycopg2 python-netaddr python-cpopen python-gevent python-pip python-devel git
+yum -y install python-django python-django-celery python-django-extensions python-django-bash-completion python-django-filter python-paramiko redis python-redis salt-master postgresql postgresql-server postgresql-devel postgresql-libs postgresql-contrib python-psycopg2 python-netaddr python-cpopen python-gevent python-pip python-devel
 
 pip install djangorestframework psycogreen
 pip install celery --upgrade
@@ -144,7 +144,7 @@ yes |cp $USM_HOME/usm_wrappers/*.sls /srv/salt
 
 set +x
 
-printf "${RED}Please Make Suitable Firewall settings by unblocking 4505-4506 ports for communication with salt and your HTTP port used for USM....${NC}\n"
+printf "${YELLOW}Please Make Suitable Firewall settings by unblocking 4505-4506 ports for communication with salt and your HTTP port used for USM....${NC}\n"
 
 printf "${GREEN}You Can start the USM application by running following command in $USM_HOME dir\nCommand: python manage.py runserver IPAddress:PORT${NC}\n"
 

--- a/usm_rest_api/v1/views/views.py
+++ b/usm_rest_api/v1/views/views.py
@@ -68,8 +68,8 @@ If authentication is successful, 200 is returned, if it is unsuccessful
 then 401 is returend.
     """
     if request.method == 'POST':
-        username = request.DATA.get('username', None)
-        password = request.DATA.get('password', None)
+        username = request.data.get('username', None)
+        password = request.data.get('password', None)
         msg = {}
         if not username:
             msg['username'] = 'This field is required'


### PR DESCRIPTION
This patch adds a script install.sh to set up the
usm core. This script internally does the
following:
*installs the necessary packages.
*sets up the DB
*clones and sets up the USM app
*sets up celery,salt and redis

Note: the install script is tested on f-22 and
works fine for first time install.

This patch also makes small changes to readme.md

Signed-off-by: Darshan N dnarayan@redhat.com
